### PR TITLE
[feature] 設定ファイルをYAML形式にする #12

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,11 +1,11 @@
-import json
 import logging
 import os
 
+import yaml
 from discord.ext import commands
 
-with open(os.path.expanduser('~/.bot-config.json'), 'r') as f:
-    bot_config = json.load(f)
+with open(os.path.expanduser('~/.bot-config.yml'), 'r') as f:
+    bot_config = yaml.full_load(f)
 
 logging.basicConfig(
     level=bot_config.get('logging_level', 'WARNING'))


### PR DESCRIPTION
botの設定ファイルをYAML形式で書くようにする。
設定ファイルは ~/.bot-config.yml
(将来的にはオプションで指定したい)
YAMLのローダーにはPyYAMLを使用するので
pipによるインストールが必要。