### PR TITLE
[fix] ArtifactSpoiler機能でKILL_*フラグが適切に表示されない #25

### DIFF
--- a/ArtifactSpoiler.py
+++ b/ArtifactSpoiler.py
@@ -426,7 +426,9 @@ FROM
 
     async def send_artifact_info(self, ctx: commands.Context, art: Artifact):
         art_desc = self.describe_artifact(art)
-        embed = discord.Embed(title=art_desc[0], description=art_desc[1])
+        embed = discord.Embed(
+            title=discord.utils.escape_markdown(art_desc[0]),
+            description=discord.utils.escape_markdown(art_desc[1]))
         await ctx.reply(embed=embed)
 
     async def send_error(self, ctx: commands.Context, error_msg: str):


### PR DESCRIPTION
KILL_*フラグは、「*対象種族*」のように表示するが、このまま
出力するとDiscordのMarkdown表現(イタリック表記)に該当するため
*の表示が消えてしまう。
Markdown表記をエスケープする、discord.utils.escape_markdownという
関数があるので、それを使って*の表示が消えてしまわないようにする。