### PR TITLE
[fix] あいまい検索で大文字小文字を区別しない

### DIFF
--- a/ListSearch.py
+++ b/ListSearch.py
@@ -46,7 +46,7 @@ async def search(
     if not candidates:
         suggests = sorted(
             items,
-            key=lambda x: fuzz.partial_ratio(x[name], search_str), reverse=True
+            key=lambda x: fuzz.partial_ratio(search_str, str.lower(x[name])), reverse=True
         )[:10]
         choice = await CandidatesSelector.select(ctx, "もしかして:", [i[name] for i in suggests])
         return (suggests[choice] if choice is not None else None, None)


### PR DESCRIPTION
あいまい検索で大文字小文字を区別すると、大文字小文字の
違いでかなり正解率が下がることがあるので、区別しない
ようにする。