### PR TITLE
[udpate] コマンドプレフィックスを追加

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,7 +10,7 @@ with open(os.path.expanduser('~/.bot-config.yml'), 'r') as f:
 logging.basicConfig(
     level=bot_config.get('logging_level', 'WARNING'))
 
-bot = commands.Bot('$')
+bot = commands.Bot(['$', '!', '?', '＄', '！', '？'])
 
 for ext in bot_config.get("extensions"):
     bot.ext = ext


### PR DESCRIPTION
'$'はスマホだと入力しづらい事があるので、'!'と'?'も
コマンドプレフィックスとして許可する。
また、コマンドプレフィックスは全角の場合にも
有効とする。