### PR TITLE
[Fix] 発動情報の読み込み失敗

### DIFF
--- a/ActivationInfoReader.py
+++ b/ActivationInfoReader.py
@@ -6,7 +6,7 @@ from typing import Iterator
 class ActivationInfoReader():
     def get_activation_info_list(self, info_table_src: str) -> Iterator[dict]:
         pattern = re.compile(
-            r'{\s*"(\w+)",\s*(\w+),\s*([-]?\d+)\s*,\s*([-]?\d+)\s*,'
+            r'{\s*"(\w+)",\s*(\S+),\s*([-]?\d+)\s*,\s*([-]?\d+)\s*,'
             r'\s*{\s*([-]?\d+)\s*,\s*([-]?\d+)\s*},\s*_\("(.+)",\s*"(.+)"\)\s*}'
         )
         prev_line = None


### PR DESCRIPTION
アーティファクトの発動情報の定義がenum classになり "::" が入るようになった
事により activation-info-table.cpp のパースに失敗するようになっていた。
"::" が入っても問題ないように正規表現を修正する。