### PR TITLE
feat: 変愚蛮怒の新着スコア通知でスクリーンダンプのURLも出力する

### DIFF
--- a/RssFeedChecker.py
+++ b/RssFeedChecker.py
@@ -67,6 +67,17 @@ class RssChecker:
             i.last_updated_time = datetime.datetime(
                 *i.updated_parsed[:6]).timestamp()
 
+    async def build_embed(self, embed: discord.Embed, items: List[feedparser.FeedParserDict],
+                          shortener: bitlyshortener.Shortener):
+        new_item_links = [getattr(i, 'link') for i in items]
+        loop = asyncio.get_running_loop()
+        shorten_urls_dict = await loop.run_in_executor(None, shortener.shorten_urls_to_dict, new_item_links)
+        for i in items:
+            embed.add_field(
+                name=i.title,
+                value=shorten_urls_dict.get(i.link, "")
+            )
+
 
 class PukiwikiRssChecker(RssChecker):
     def add_last_updated_time(self, d: feedparser.FeedParserDict):
@@ -74,6 +85,22 @@ class PukiwikiRssChecker(RssChecker):
             i.last_updated_time = datetime.datetime.strptime(
                 i.summary, '%a, %d %b %Y %H:%M:%S %Z'
             ).timestamp()
+
+
+class HengscoreRssChecker(RssChecker):
+    async def build_embed(self, embed: discord.Embed, items: List[feedparser.FeedParserDict],
+                          shortener: bitlyshortener.Shortener):
+        new_item_links: List[str] = [getattr(i, 'link') for i in items]
+        new_item_links += [i.replace("show_dump.php?", "show_screen.php?") for i in new_item_links]
+        loop = asyncio.get_running_loop()
+        shorten_urls_dict = await loop.run_in_executor(None, shortener.shorten_urls_to_dict, new_item_links)
+        for i in items:
+            dump_url = shorten_urls_dict.get(i.link, "")
+            screen_url = shorten_urls_dict.get(i.link.replace("show_dump.php?", "show_screen.php?"), "")
+            embed.add_field(
+                name=i.title,
+                value=f"**dump:**{dump_url}\n**screen:**{screen_url}"
+            )
 
 
 class RssCheckCog(commands.Cog):
@@ -104,16 +131,9 @@ class RssCheckCog(commands.Cog):
             if len(new_items) == 0:
                 continue
 
-            new_item_links = [getattr(i, 'link') for i in new_items]
-            loop = asyncio.get_running_loop()
-            shorten_urls_dict = await loop.run_in_executor(None, self.shortener.shorten_urls_to_dict, new_item_links)
             channel = self.bot.get_channel(checker.send_channel_id)
             embed = discord.Embed(title=checker.name)
-            for i in new_items:
-                embed.add_field(
-                    name=i.title,
-                    value=shorten_urls_dict.get(i.link, "")
-                )
+            await checker.build_embed(embed, new_items, self.shortener)
             await channel.send(embed=embed)
 
     @checker_task.before_loop


### PR DESCRIPTION
通常のRssFeedCheckerではURLのリンクのみを出力するが、変愚蛮怒の新着スコア通知の場合
URLのリンクはキャラクタダンプへのリンクである。
しかし、スクリーンダンプも同時に確認したいという要望があったため、変愚蛮怒の新着スコア
通知ではスクリーンダンプへのリンクも合わせて出力するようにする。
設定ファイルで checker に HengscoreRssChecker を指定することで有効となる。