### PR TITLE
fix: Android版Discordクライアントで変愚蛮怒スコア通知の絵文字が表示されない

### DIFF
--- a/RssFeedChecker.py
+++ b/RssFeedChecker.py
@@ -95,7 +95,7 @@ class HengscoreRssChecker(RssChecker):
             screen_url = dump_url.replace("show_dump.php?", "show_screen.php?")
             embed.add_field(
                 name=i.title,
-                value=f"[:page_facing_up:dump]({dump_url}) [:camera:screen]({screen_url})"
+                value=f":page_facing_up:[dump]({dump_url}) :camera:[screen]({screen_url})"
             )
 
 


### PR DESCRIPTION
PC版やiOS版では大丈夫だが、Android版だとMarkdownのURLリンクテキスト内の絵文字が
表示されない。リンク外に出しておくと表示されるのでひとまずそのようにしておく。