### PR TITLE
fix: Message Content Intent を有効にする

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,7 @@
 import logging
 import os
 
+import discord
 import yaml
 from discord.ext import commands
 
@@ -10,7 +11,10 @@ with open(os.path.expanduser('~/.bot-config.yml'), 'r') as f:
 logging.basicConfig(
     level=bot_config.get('logging_level', 'WARNING'))
 
-bot = commands.Bot(['$', '!', '?', '＄', '！', '？'])
+intents = discord.Intents.default()
+intents.message_content = True
+
+bot = commands.Bot(['$', '!', '?', '＄', '！', '？'], intents=intents)
 
 for ext in bot_config.get("extensions"):
     bot.ext = ext


### PR DESCRIPTION
将来的に Discord では Message Content Intent が有効でないと Bot がサーバのメッ
セージを読むことができなくなるので対応する。