### PR TITLE
feat: Discord API ラッパーライブラリを discord.py に戻す

### DIFF
--- a/ArtifactSpoiler.py
+++ b/ArtifactSpoiler.py
@@ -322,5 +322,5 @@ class ArtifactSpoilerCog(commands.Cog):
             await asyncio.gather(*update_tasks)
 
 
-def setup(bot):
-    bot.add_cog(ArtifactSpoilerCog(bot, bot.ext))
+async def setup(bot):
+    await bot.add_cog(ArtifactSpoilerCog(bot, bot.ext))

--- a/ChannelLogger.py
+++ b/ChannelLogger.py
@@ -36,5 +36,5 @@ class ChannelLogger(commands.Cog):
         await self._bot.wait_until_ready()
 
 
-def setup(bot):
-    bot.add_cog(ChannelLogger(bot, bot.ext))
+async def setup(bot):
+    await bot.add_cog(ChannelLogger(bot, bot.ext))

--- a/DiceRoll.py
+++ b/DiceRoll.py
@@ -31,5 +31,5 @@ class DiceRoll(commands.Cog):
         return discord.Embed(title=roll_sum, description=result_seq)
 
 
-def setup(bot):
-    bot.add_cog(DiceRoll())
+async def setup(bot):
+    await bot.add_cog(DiceRoll())

--- a/MonsterSpoiler.py
+++ b/MonsterSpoiler.py
@@ -81,5 +81,5 @@ ID:{id}  階層:{level}  レア度:{rarity}  加速:{speed}  HP:{hp}  AC:{ac}  E
             self.mon_info_list = await self.m_info.get_monster_info_list()
 
 
-def setup(bot):
-    bot.add_cog(MonsterSpoiler(bot, bot.ext))
+async def setup(bot):
+    await bot.add_cog(MonsterSpoiler(bot, bot.ext))

--- a/RssFeedChecker.py
+++ b/RssFeedChecker.py
@@ -125,5 +125,5 @@ class RssCheckCog(commands.Cog):
         await self.bot.wait_until_ready()
 
 
-def setup(bot: commands.Bot):
-    bot.add_cog(RssCheckCog(bot, bot.ext))
+async def setup(bot: commands.Bot):
+    await bot.add_cog(RssCheckCog(bot, bot.ext))

--- a/SourceCodeLister.py
+++ b/SourceCodeLister.py
@@ -86,5 +86,5 @@ class SourceCodeLister(commands.Cog):
         await ctx.reply(embed=embed)
 
 
-def setup(bot):
-    bot.add_cog(SourceCodeLister(bot, bot.ext))
+async def setup(bot):
+    await bot.add_cog(SourceCodeLister(bot, bot.ext))

--- a/Translator.py
+++ b/Translator.py
@@ -53,5 +53,5 @@ class Translator(commands.Cog):
             await ctx.reply(error_msg)
 
 
-def setup(bot):
-    bot.add_cog(Translator(bot))
+async def setup(bot):
+    await bot.add_cog(Translator(bot))

--- a/bot.py
+++ b/bot.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 
@@ -5,20 +6,38 @@ import discord
 import yaml
 from discord.ext import commands
 
-with open(os.path.expanduser("~/.bot-config.yml"), "r") as f:
-    bot_config = yaml.full_load(f)
 
-logging.basicConfig(level=bot_config.get("logging_level", "WARNING"))
+class Bot(commands.Bot):
+    def __init__(self, command_prefix, *, intents: discord.Intents, bot_config: dict):
+        super().__init__(command_prefix, intents=intents)
+        self.bot_config = bot_config
 
-intents = discord.Intents.default()
-intents.message_content = True
+    async def setup_hook(self):
+        for ext in self.bot_config.get("extensions", []):
+            if (extension_name := ext.get("name")) is None:
+                continue
+            if logging_level := ext.get("logging_level"):
+                logging.getLogger(extension_name).setLevel(logging_level)
+            self.ext = ext
+            await self.load_extension(extension_name)
 
-bot = commands.Bot(["$", "!", "?", "＄", "！", "？"], intents=intents)
 
-for ext in bot_config.get("extensions"):
-    bot.ext = ext
-    bot.load_extension(ext["name"])
-    if logging_level := ext.get("logging_level"):
-        logging.getLogger(ext["name"]).setLevel(logging_level)
+async def main():
+    with open(os.path.expanduser("~/.bot-config.yml"), "r") as f:
+        bot_config = yaml.full_load(f)
 
-bot.run(bot_config["token"])
+    logging.basicConfig(level=bot_config.get("logging_level", "WARNING"))
+
+    intents = discord.Intents.default()
+    intents.message_content = True
+
+    bot = Bot(
+        ["$", "!", "?", "＄", "！", "？"],
+        intents=intents,
+        bot_config=bot_config,
+    )
+    await bot.start(bot_config["token"])
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ async-timeout==3.0.1
 attrs==21.4.0
 certifi==2021.10.8
 chardet==3.0.4
+discord.py==2.1.0
 feedparser==6.0.8
 fuzzywuzzy==0.18.0
 googletrans==4.0.0rc1
@@ -16,7 +17,6 @@ httpx==0.13.3
 hyperframe==5.2.0
 idna==2.10
 multidict==6.0.2
-py-cord==2.0.0b7
 PyYAML==6.0
 rfc3986==1.5.0
 sgmllib3k==1.0.0


### PR DESCRIPTION
discord.py の開発停止を契機に Discord API ラッパーライブラリを discord.py の fork プロジェクトである pycord に移行していたが、discord.py の開発が再開されたので 再度 Discord API ラッパーライブラリを discord.py に戻す。
また、discord.py のバージョンアップに伴い既存のコードの変更も必要となるので、初期化
処理周りを中心にコードの修正を行う。