### PR TITLE
feat: ListSearch: 完全一致する場合はそれを採用する

### DIFF
--- a/ListSearch.py
+++ b/ListSearch.py
@@ -86,6 +86,12 @@ async def search(
 
     name = ename_key if english else name_key
 
+    # 完全一致チェック
+    exact_matches = [i for i in candidates if i.get(name, "") == search_str]
+    if len(exact_matches) == 1:
+        await on_found(ctx, exact_matches[0], callback_arg)
+        return
+
     if not candidates:
         suggests = sorted(
             items,


### PR DESCRIPTION
検索処理で完全一致するものが存在する場合は、他に部分一致するものがあっても候補を表示せず完全一致したものを採用する。
ただし、完全一致したものが複数ある場合は従来どおり部分一致するものも含め候補を表示する。