### PR TITLE
feat: jsoncのtrailling commaをサポート

### DIFF
--- a/Jsonc.py
+++ b/Jsonc.py
@@ -1,6 +1,6 @@
-import json
-import re
 from typing import Any
+
+import json5
 
 
 def parse_jsonc(jsonc_data: str) -> Any:
@@ -14,6 +14,5 @@ def parse_jsonc(jsonc_data: str) -> Any:
     Returns:
         Any: パースした結果のオブジェクト
     """
-    json_data = re.sub(r"/\*[\s\S]*?\*/|//.*", "", jsonc_data)
-    json_obj = json.loads(json_data)
+    json_obj = json5.loads(jsonc_data)
     return json_obj

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ httpcore==0.9.1
 httpx==0.13.3
 hyperframe==5.2.0
 idna==2.10
+json5==0.12.1
 multidict==6.0.5
 PyYAML==6.0.1
 rfc3986==1.5.0


### PR DESCRIPTION
変愚蛮怒のjsoncファイルでtrailling comma形式を標準とするようにしたため、trailling comma（およびコメント）をサポートするjson5パッケージを使用してjsoncファイルをパースするように変更する。